### PR TITLE
Fix 1.1.1: add `sampled` flag handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>ru.alfastrah.api</groupId>
     <artifactId>spring-boot-tracing-starter</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <name>spring-boot-tracing-starter</name>
     <description>AutoConfiguration for Zipkin Tracing and observability via Kafka</description>
     <properties>

--- a/src/main/java/ru/alfastrah/api/tracing/util/Constants.java
+++ b/src/main/java/ru/alfastrah/api/tracing/util/Constants.java
@@ -40,7 +40,7 @@ public class Constants {
                         "00", // https://www.w3.org/TR/trace-context/#version
                         traceContext.traceId(), // https://www.w3.org/TR/trace-context/#trace-id
                         traceContext.parentId(), // https://www.w3.org/TR/trace-context/#parent-id
-                        "01" // https://www.w3.org/TR/trace-context/#sampled-flag
+                        Boolean.TRUE.equals(traceContext.sampled()) ? "01" : "00" //https://www.w3.org/TR/trace-context/#sampled-flag
                 ));
 
         private Helpers() {

--- a/src/test/java/ru/alfastrah/api/tracing/observability/soap/SoapTraceParentOutDatabindingInterceptorTest.java
+++ b/src/test/java/ru/alfastrah/api/tracing/observability/soap/SoapTraceParentOutDatabindingInterceptorTest.java
@@ -78,8 +78,8 @@ class SoapTraceParentOutDatabindingInterceptorTest {
 
     @ParameterizedTest
     @MethodSource("provideMessages")
-    void handleMessage_shouldAddTraceParentHeader(Message message) {
-        final TraceContext mockedTraceContext = getTraceContext();
+    void handleMessage_shouldAddTraceParentHeader_sampled(Message message) {
+        final TraceContext mockedTraceContext = getTraceContext(true);
 
         when(currentTraceContext.context())
                 .thenReturn(mockedTraceContext);
@@ -110,6 +110,40 @@ class SoapTraceParentOutDatabindingInterceptorTest {
         verifyNoMoreInteractions(currentTraceContext);
     }
 
+    @ParameterizedTest
+    @MethodSource("provideMessages")
+    void handleMessage_shouldAddTraceParentHeader_notSampled(Message message) {
+        final TraceContext mockedTraceContext = getTraceContext(false);
+
+        when(currentTraceContext.context())
+                .thenReturn(mockedTraceContext);
+
+        @SuppressWarnings("unchecked") final Map<String, List<String>> headers = (Map<String, List<String>>) message.get(Message.PROTOCOL_HEADERS);
+        final int initialHeaderMapSize = isNull(headers) ? 0 : headers.size();
+
+        interceptor.handleMessage(message);
+
+        final StringJoiner expectedTraceParentValue = new StringJoiner("-");
+        expectedTraceParentValue.add("00");
+        expectedTraceParentValue.add(TRACE_ID);
+        expectedTraceParentValue.add(PARENT_ID);
+        expectedTraceParentValue.add("00");
+
+        assertThat(message.get(Message.PROTOCOL_HEADERS))
+                .asInstanceOf(MAP)
+                .hasSize(initialHeaderMapSize + 1)
+                .hasEntrySatisfying(TRACE_PARENT, headerValue ->
+                        assertThat(headerValue)
+                                .asInstanceOf(LIST)
+                                .hasSize(1)
+                                .first()
+                                .isEqualTo(expectedTraceParentValue.toString())
+                );
+
+        verify(currentTraceContext).context();
+        verifyNoMoreInteractions(currentTraceContext);
+    }
+
     @Test
     void handleMessage_shouldNotAddTraceParentHeader_whenNoTraceContextAvailable() {
         when(currentTraceContext.context())
@@ -123,12 +157,12 @@ class SoapTraceParentOutDatabindingInterceptorTest {
         verifyNoMoreInteractions(currentTraceContext);
     }
 
-    private TraceContext getTraceContext() {
+    private TraceContext getTraceContext(boolean sampled) {
         return tracer.traceContextBuilder()
                 .parentId(PARENT_ID)
                 .traceId(TRACE_ID)
                 .spanId(SPAN_ID)
-                .sampled(true)
+                .sampled(sampled)
                 .build();
     }
 }


### PR DESCRIPTION
Fixed function ru.alfastrah.api.tracing.util.Constants.Helpers.TO_TRACE_PARENT. It now processes the `sampled` flag from the tracing context instead of using the hardcoded value "01".
The changes comply with the requirements in the Sampled flag description at https://www.w3.org/TR/trace-context/#sampled-flag.